### PR TITLE
Add notarization data to `getblockchaininfo`

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1446,6 +1446,12 @@ RPCHelpMan getblockchaininfo()
                         {RPCResult::Type::NUM, "blocks", "the height of the most-work fully-validated chain. The genesis block has height 0"},
                         {RPCResult::Type::NUM, "headers", "the current number of headers we have validated"},
                         {RPCResult::Type::STR, "bestblockhash", "the hash of the currently best block"},
+                        {RPCResult::Type::STR, "notarizedhash", "the hash of the currently best notarized block"},
+                        {RPCResult::Type::STR, "notarizedtxid", "notarizedtxid"},
+                        {RPCResult::Type::NUM, "prevMoMheight", "prevMoMheight"},
+                        {RPCResult::Type::NUM, "notarized_MoMdepth", "notarized_MoMdepth"},
+                        {RPCResult::Type::STR, "notarized_MoM", "notarized_MoM"},
+                        {RPCResult::Type::NUM, "notarized", "the height of the currently best notarized block"},
                         {RPCResult::Type::NUM, "difficulty", "the current difficulty"},
                         {RPCResult::Type::NUM, "mediantime", "median time for the current best block"},
                         {RPCResult::Type::NUM, "verificationprogress", "estimate of verification progress [0..1]"},
@@ -1502,6 +1508,17 @@ RPCHelpMan getblockchaininfo()
     obj.pushKV("blocks",                height);
     obj.pushKV("headers",               pindexBestHeader ? pindexBestHeader->nHeight : -1);
     obj.pushKV("bestblockhash",         tip->GetBlockHash().GetHex());
+    {
+        int32_t komodo_prevMoMheight();
+        extern uint256 NOTARIZED_HASH,NOTARIZED_DESTTXID,NOTARIZED_MOM;
+        extern int32_t NOTARIZED_HEIGHT,NOTARIZED_MOMDEPTH;
+        obj.pushKV("notarizedhash",         NOTARIZED_HASH.GetHex());
+        obj.pushKV("notarizedtxid",         NOTARIZED_DESTTXID.GetHex());
+        obj.pushKV("notarized",                (int)NOTARIZED_HEIGHT);
+        obj.pushKV("prevMoMheight",                (int)komodo_prevMoMheight());
+        obj.pushKV("notarized_MoMdepth",                (int)NOTARIZED_MOMDEPTH);
+        obj.pushKV("notarized_MoM",         NOTARIZED_MOM.GetHex());
+    }
     obj.pushKV("difficulty",            (double)GetDifficulty(tip));
     obj.pushKV("mediantime",            (int64_t)tip->GetMedianTimePast());
     obj.pushKV("verificationprogress",  GuessVerificationProgress(Params().TxData(), tip));


### PR DESCRIPTION
So that KMD infrastructure can still poll blockchain info, if `getinfo` fails

Output of 'getblockchaininfo' command after changes:

```
chips-cli -testnet getblockchaininfo
{
  "chain": "test",
  "blocks": 9313,
  "headers": 9313,
  "bestblockhash": "000000051e5a03cd569128a0d1e5ecd3f4a54608dd22b9933a68baef5b495ee3",
  "notarizedhash": "0000000000000000000000000000000000000000000000000000000000000000",
  "notarizedtxid": "0000000000000000000000000000000000000000000000000000000000000000",
  "notarized": 0,
  "prevMoMheight": 0,
  "notarized_MoMdepth": 0,
  "notarized_MoM": "0000000000000000000000000000000000000000000000000000000000000000",
  "difficulty": 0.04052334382049151,
  "mediantime": 1626717187,
  "verificationprogress": 0.0003454020568628702,
  "initialblockdownload": false,
  "chainwork": "0000000000000000000000000000000000000000000000000000004d3d389126",
  "size_on_disk": 2478707,
  "pruned": false,
  "softforks": {
    "bip34": {
      "type": "buried",
      "active": false,
      "height": 21111
    },
    "bip66": {
      "type": "buried",
      "active": false,
      "height": 330776
    },
    "bip65": {
      "type": "buried",
      "active": false,
      "height": 581885
    },
    "csv": {
      "type": "buried",
      "active": false,
      "height": 770112
    },
    "segwit": {
      "type": "buried",
      "active": false,
      "height": 834624
    },
    "taproot": {
      "type": "bip9",
      "bip9": {
        "status": "active",
        "start_time": 1619222400,
        "timeout": 1628640000,
        "since": 6048,
        "min_activation_height": 0
      },
      "height": 6048,
      "active": true
    }
  },
  "warnings": "This is a pre-release test build - use at your own risk - do not use for mining or merchant applications"
}
```