### PR TITLE
Quick fix for `getblocktemplate`, gets mining and mempool working

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -163,7 +163,9 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
     // not activated.
     // TODO: replace this with a call to main to assess validity of a mempool
     // transaction (which in most cases can be a no-op).
-    fIncludeWitness = DeploymentActiveAfter(pindexPrev, chainparams.GetConsensus(), Consensus::DEPLOYMENT_SEGWIT);
+
+    fIncludeWitness = /*DeploymentActiveAfter(pindexPrev, chainparams.GetConsensus(), Consensus::DEPLOYMENT_SEGWIT)*/ true;
+    // TODO: ensure static value is okay here
 
     int nPackagesSelected = 0;
     int nDescendantsUpdated = 0;

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -775,7 +775,8 @@ static RPCHelpMan getblocktemplate()
     pblock->nNonce = 0;
 
     // NOTE: If at some point we support pre-segwit miners post-segwit-activation, this needs to take segwit support into consideration
-    const bool fPreSegWit = !DeploymentActiveAfter(pindexPrev, consensusParams, Consensus::DEPLOYMENT_SEGWIT);
+    const bool fPreSegWit = false;
+    //const bool fPreSegwit = !DeploymentActiveAfter(pindexPrev, consensusParams, Consensus::DEPLOYMENT_SEGWIT);
 
     UniValue aCaps(UniValue::VARR); aCaps.push_back("proposal");
 


### PR DESCRIPTION
A less simple fix might be in order for this. Not sure if it matters for mainnet.

Output of `getblocktemplate`, after changes (raw tx hex was omitted for brevity):

```
chips-cli -testnet getblocktemplate '{"rules": ["segwit"]}'
{
  "capabilities": [
    "proposal"
  ],
  "version": 536870912,
  "rules": [
    "csv",
    "!segwit",
    "taproot"
  ],
  "vbavailable": {
  },
  "vbrequired": 0,
  "previousblockhash": "0000000b447f2902ce394f49e4d95b74c125d5adbf1b12111a0179ee63e40c2a",
  "transactions": [
    {
      "data": "....",
      "txid": "91a0c6531b2c0987b9298694824ba11e9c88c6d4146285f8f15f139d58e7cdd4",
      "hash": "e6236d1e763360a0484b960811a1fbec94911ec7dc4fa9c2c403d286674a7c16",
      "depends": [
      ],
      "fee": 415000,
      "sigops": 1,
      "weight": 661
    },
    {
      "data": ".....",
      "txid": "e12e05faeef0834e69b696fb47118a2714fad81045a5e443bb23a5967f15ad69",
      "hash": "c2e0d92ae74602b12caa532cd7288135cb135ca60eba03226a389b7ac075847f",
      "depends": [
      ],
      "fee": 41500,
      "sigops": 1,
      "weight": 661
    },
    {
      "data": ".....",
      "txid": "f62da2a868405419d31c2e1bc1d91dfc206d1bc9bfc270d1e47b12bfba14ed87",
      "hash": "7aef8684ea0a02e78ad653263b46f5d3a087b4f630e3c4cc8d53c64eedcea298",
      "depends": [
      ],
      "fee": 64000,
      "sigops": 2,
      "weight": 1024
    },
    {
      "data": "...",
      "txid": "0c74da539e6e61d00545d8b5634f88098006ba22d0951ccc18d06f5fd0f35aae",
      "hash": "112f31fa26fb66d77038eede46f29b79e94eb23027276ed1cbf11c3ae0738fc6",
      "depends": [
      ],
      "fee": 2279500,
      "sigops": 100,
      "weight": 36470
    },
    {
      "data": ".....",
      "txid": "3ef80d243597a53667c00bc428b3ed65cc9b107377500765206b89a77cddfbcc",
      "hash": "597a4ab1b7ddc0893c20cef7776f59cad3e36c16185523ba6cd3472982ebe0a1",
      "depends": [
      ],
      "fee": 91180,
      "sigops": 100,
      "weight": 36469
    }
  ],
  "coinbaseaux": {
  },
  "coinbasevalue": 5002891180,
  "longpollid": "0000000b447f2902ce394f49e4d95b74c125d5adbf1b12111a0179ee63e40c2a7",
  "target": "00000018ad400000000000000000000000000000000000000000000000000000",
  "mintime": 1626717733,
  "mutable": [
    "time",
    "transactions",
    "prevblock"
  ],
  "noncerange": "00000000ffffffff",
  "sigoplimit": 80000,
  "sizelimit": 4000000,
  "weightlimit": 4000000,
  "curtime": 1626719182,
  "bits": "1d18ad40",
  "height": 9317,
  "default_witness_commitment": "6a24aa21a9ed3678fd31e83e2f117c093e2f6fd391fd5dddd91e8dd7754d77f8920ef4e569e4"
}
```


Mining script gave following output: 

```
{
  "address": "2MtVYgrUk39D8cDTK5KZ87F1sdfqykKbd7t",
  "blocks": [
    "00000012b8c4d12963bd1dd1aca2dffa3e36df42c00853f6f8ca759ed9d00204"
  ]
}
```

Explorer also showing this block mined with 7 txs: https://testnet.chips.cash/block/00000012b8c4d12963bd1dd1aca2dffa3e36df42c00853f6f8ca759ed9d00204