### PR TITLE
Uncomment unexpected-witness check in ContextualCheckBlock()

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3288,13 +3288,13 @@ static bool ContextualCheckBlock(const CBlock& block, BlockValidationState& stat
     }
 
 //  // No witness data is allowed in blocks that don't commit to witness data, as this would otherwise leave room for spam
-//  if (!fHaveWitness) {
-//    for (const auto& tx : block.vtx) {
-//          if (tx->HasWitness()) {
-//              return state.Invalid(BlockValidationResult::BLOCK_MUTATED, "unexpected-witness", strprintf("%s : unexpected witness data found", __func__));
-//          }
-//    }
-//  }
+  if (!fHaveWitness) {
+    for (const auto& tx : block.vtx) {
+          if (tx->HasWitness()) {
+              return state.Invalid(BlockValidationResult::BLOCK_MUTATED, "unexpected-witness", strprintf("%s : unexpected witness data found", __func__));
+          }
+    }
+  }
 
     // After the coinbase witness reserved value and commitment are verified,
     // we can check if the block weight passes (before we've checked the


### PR DESCRIPTION
~~This was commented out at some point, and doesn't appear to interfere with any functionality.  Best to leave it in, provided that remains true in testing.~~

Edit: Breaks mining with message: `ERROR: TestBlockValidity: Consensus::ContextualCheckBlock: unexpected-witness, ContextualCheckBlock : unexpected witness data found`
