### PR TITLE
Fix broken calc_MoM command

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2766,13 +2766,23 @@ static std::vector<uint256> ComputeMerkleBranch(const std::vector<uint256>& leav
 static RPCHelpMan calc_MoM()
 {
     return RPCHelpMan{"calc_MoM",
-                "\n",
-                {},
+                                "Calculates MoM for a given height and MoMdepth\n",
+                {
+                  {"height", RPCArg::Type::NUM, RPCArg::Optional::NO, "requested height"},
+                  {"MoMdepth", RPCArg::Type::NUM, RPCArg::Optional::NO, "requested depth for MoM"},
+                },
                 RPCResult{
-                    RPCResult::Type::NUM, "", "The current block count"},
+                  RPCResult::Type::OBJ, "", "",
+                  {
+                    {RPCResult::Type::STR, "coin", "active coin for calculation"},
+                    {RPCResult::Type::NUM, "height", "requested block height"},
+                    {RPCResult::Type::NUM, "MoMdepth", "requested MoMdepth"},
+                    {RPCResult::Type::STR_HEX, "MoM", "calculated MoM"},
+                  }
+                },
                 RPCExamples{
-                    HelpExampleCli("getblockcount", "")
-            + HelpExampleRpc("getblockcount", "")
+                    HelpExampleCli("calc_MoM", "100 1")
+            + HelpExampleRpc("calc_MoM", "100, 1")
                 },
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {


### PR DESCRIPTION
Prior to fix: 

```
./chips-cli -testnet calc_MoM 100 1
error code: -1
error message:
calc_MoM


Result:
n    (numeric) The current block count

Examples:
> bitcoin-cli getblockcount 
> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "getblockcount", "params": []}' -H 'content-type: text/plain;' http://127.0.0.1:8332/
```

After fix:

```
./chips-cli -testnet calc_MoM 100 1
{
  "coin": "CHIPS",
  "height": 100,
  "MoMdepth": 1,
  "MoM": "64466cf635c71f921cd34a7afe5d9e979cb5c21a7a19985954e9aa04abf7467c"
}
```