### PR TITLE
Fix broken height_MoM RPC

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2784,7 +2784,6 @@ static RPCHelpMan calc_MoM()
     MoMdepth = atoi(request.params[1].get_str().c_str());
     if ( height <= 0 || MoMdepth <= 0 || MoMdepth >= height )
         throw std::runtime_error("calc_MoM illegal height or MoMdepth\n");
-    //fprintf(stderr,"height_MoM height.%d\n",height);
     MoM = komodo_calcMoM(height,MoMdepth);
     ret.pushKV("coin",(char *)(ASSETCHAINS_SYMBOL[0] == 0 ? "KMD" : ASSETCHAINS_SYMBOL));
     ret.pushKV("height",height);
@@ -2798,13 +2797,29 @@ static RPCHelpMan calc_MoM()
 static RPCHelpMan height_MoM()
 {
     return RPCHelpMan{"height_MoM",
-                "\n",
-                {},
+                "Calculates MoM for a given height, if it exists\n",
+                {
+                  {"height", RPCArg::Type::NUM, RPCArg::Optional::NO, "height for MoM calculation"},
+                },
                 RPCResult{
-                    RPCResult::Type::NUM, "", "The current block count"},
+                    RPCResult::Type::OBJ, "", "",
+                    {
+                        {RPCResult::Type::STR, "coin", "active coin"},
+                        {RPCResult::Type::NUM, "height", "requested block height"},
+                        {RPCResult::Type::NUM, "timestamp", "timestamp"},
+                        {RPCResult::Type::NUM, "depth", "MoMdepth"},
+                        {RPCResult::Type::NUM, "notarized_height", "height of last notarization"},
+                        {RPCResult::Type::STR_HEX, "MoM", "MoM hash"},
+                        {RPCResult::Type::STR_HEX, "kmdtxid", "txid from komodo"},
+                        {RPCResult::Type::STR_HEX, "MoMoM", "MoMoM hash"},
+                        {RPCResult::Type::NUM, "MoMoMoffset", "MoMoffset"},
+                        {RPCResult::Type::NUM, "kmdstarti", "kmdstarti"},
+                        {RPCResult::Type::NUM, "kmdendi", "kmdendi"},
+                    }
+                 },
                 RPCExamples{
-                    HelpExampleCli("getblockcount", "")
-            + HelpExampleRpc("getblockcount", "")
+                    HelpExampleCli("height_MoM", "100")
+            + HelpExampleRpc("height_MoM", "100")
                 },
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {


### PR DESCRIPTION
Output when calling after changes:

With `height = -1` (converted to max height by chipsd)
```
./chips-cli -testnet height_MoM -1 
{
  "coin": "CHIPS",
  "height": 18261,
  "timestamp": 0,
  "error": "no MoM for height"
}
```

Without parameters (help text):

```
./chips-cli -testnet height_MoM 
error code: -1
error message:
height_MoM height
Calculates MoM for a given height, if it exists

Arguments:
1. height    (numeric, required) height for MoM calculation

Result:
{                            (json object)
  "coin" : "str",            (string) active coin
  "height" : n,              (numeric) requested block height
  "timestamp" : n,           (numeric) timestamp
  "depth" : n,               (numeric) MoMdepth
  "notarized_height" : n,    (numeric) height of last notarization
  "MoM" : "hex",             (string) MoM hash
  "kmdtxid" : "hex",         (string) txid from komodo
  "MoMoM" : "hex",           (string) MoMoM hash
  "MoMoMoffset" : n,         (numeric) MoMoffset
  "kmdstarti" : n,           (numeric) kmdstarti
  "kmdendi" : n              (numeric) kmdendi
}
```
