### PR TITLE
Set an abritrary default txfee

### DIFF
--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -66,7 +66,7 @@ std::unique_ptr<WalletDatabase> MakeWalletDatabase(const std::string& name, cons
 std::shared_ptr<CWallet> GetMainWallet();
 
 //! -paytxfee default
-constexpr CAmount DEFAULT_PAY_TX_FEE = 0;
+constexpr CAmount DEFAULT_PAY_TX_FEE = 2500000;
 //! -fallbackfee default
 static const CAmount DEFAULT_FALLBACK_FEE = 0;
 //! -discardfee default


### PR DESCRIPTION
Removes need for user to manually call `chips-cli settxfee 0.025`or similar.