### PR TITLE
Add komodo_(dis)connect_block() function calls

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1595,6 +1595,8 @@ DisconnectResult CChainState::DisconnectBlock(const CBlock& block, const CBlockI
         }
     }
 
+    komodo_disconnect((CBlockIndex *)pindex,(CBlock *)&block);
+
     // move best block pointer to prevout block
     view.SetBestBlock(pindex->pprev->GetBlockHash());
 
@@ -2004,6 +2006,8 @@ bool CChainState::ConnectBlock(const CBlock& block, BlockValidationState& state,
 
     int64_t nTime6 = GetTimeMicros(); nTimeCallbacks += nTime6 - nTime5;
     LogPrint(BCLog::BENCH, "    - Callbacks: %.2fms [%.2fs (%.2fms/blk)]\n", MILLI * (nTime6 - nTime5), nTimeCallbacks * MICRO, nTimeCallbacks * MILLI / nBlocksTotal);
+
+    komodo_connectblock(pindex,*(CBlock *)&block);
 
     return true;
 }


### PR DESCRIPTION
Adds necessary function calls to `komodo_connectblock()` and `komodo_disconnectblock()`.  These were omitted in initial codebase upgrade.