### PR TITLE
Add definitions for ImportAddress, uncomment in kmd_validation015.h

### DIFF
--- a/src/komodo_validation015.h
+++ b/src/komodo_validation015.h
@@ -491,7 +491,7 @@ int32_t komodo_importaddress(std::string addr)
             else
             {
                 printf("komodo_importaddress %s\n",EncodeDestination(address).c_str());
-                //ImportAddress(pwallet, address, addr);
+                ImportAddress(pwallet, address, addr);
                 return(1);
             }
         }


### PR DESCRIPTION
- Things have changed quite a bit within scripts, particularly since the addition of Taproot
- Handling for `CScriptID`s is somewhat different now too (For discerning `CTxDestination` from them), so this should be checked for validity and proper function