### PR TITLE
increase op_return relay size

### DIFF
--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -35,7 +35,7 @@ public:
  * Default setting for nMaxDatacarrierBytes. 80 bytes of data, +1 for OP_RETURN,
  * +2 for the pushdata opcodes.
  */
-static const unsigned int MAX_OP_RETURN_RELAY = 83;
+static const unsigned int MAX_OP_RETURN_RELAY = 9990;
 
 /**
  * A data carrying output is an unspendable output containing data. The script


### PR DESCRIPTION
match existing op_return relay policy rule from legacy chips codebase (https://github.com/chips-blockchain/chips/blob/master/src/script/standard.h#L30)